### PR TITLE
Update documentation and improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM ubuntu:18.04
+# For exiftool 12.40
+FROM ubuntu:22.04
 
 ARG MEDIASDK_UBUNTU_DEB=libMediaSDK-dev_2.0-0_amd64_ubuntu18.04.deb
 
 RUN apt update && apt install software-properties-common -y && \
+ # For libjasper-dev
  add-apt-repository 'deb http://security.ubuntu.com/ubuntu xenial-security main' && \
+ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 && \
  apt update && \
- apt install curl git build-essential libjpeg-dev libtiff-dev libjasper-dev -y
+ apt install curl git build-essential libjpeg-dev libtiff-dev libjasper-dev ffmpeg exiftool -y
 WORKDIR /root
 COPY ${MEDIASDK_UBUNTU_DEB} .
 RUN dpkg -i ${MEDIASDK_UBUNTU_DEB}


### PR DESCRIPTION
We need a later version of `exiftool` than that's shipped in Ubuntu 18.04, and therefore we need to add some hacks in the Dockerfile.