### PR TITLE
[Do Not Merge] reference PR for buggy media sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 libMediaSDK-dev_2.0-0_amd64_ubuntu18.04.deb
 libMediaSDK-dev_2.0-6_amd64_ubuntu18.04.deb
+libMediaSDK-dev-3.0.1.2-20250418_153137-amd64.deb
 **/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # For exiftool 12.40
 FROM ubuntu:22.04
 
-ARG MEDIASDK_UBUNTU_DEB=libMediaSDK-dev_2.0-6_amd64_ubuntu18.04.deb
+ARG MEDIASDK_UBUNTU_DEB=libMediaSDK-dev-3.0.1.2-20250418_153137-amd64.deb
 ENV PATH="${PATH}:/root/scripts"
 
 RUN apt update && apt install software-properties-common -y && \

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ If you are a Linux user, this utility can come in handy, because as of early
   video files
 - [Fill out the application](https://www.insta360.com/sdk/home), get approved,
   and download the Insta360 media SDK for Linux
-  - The latest media SDK I have access to is `LinuxSDK20241128.zip`. It contains
-    a pre-built package `libMediaSDK-dev_2.0-6_amd64_ubuntu18.04.deb` for Ubuntu
-    18.04, which is the only file I need from the zip
+  - The latest media SDK I have access to is
+    `Linux_CameraSDK-2.0.2-build1-20250418_MediaSDK-3.0.1-build1-20250418.zip`.
+    It contains a pre-built package
+    `libMediaSDK-dev-3.0.1.2-20250418_153137-amd64.deb` for Ubuntu, which is the
+    only file I need from the zip
 
 ## My workflow for converting and joining 360-degree videos
 


### PR DESCRIPTION
This is a reference PR for an attempt to upgrade the libMediaSDK to version 3.0.1.2, which was published in April 2025.

This version of the media SDK, or at least the Debian installer libMediaSDK-dev-3.0.1.2-20250418_153137-amd64.deb, is buggy. I got the following error when trying to execute `MediaSDKTest --help` from the container shell.

```bash
root@51e1f959aae2:~# MediaSDKTest --help
glfwDisplayMgr: failed to setup GLFW!
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'
GLFW error: '65537', 'The GLFW library is not initialized'

*** ORYOL ASSERT: window != nullptr
  msg=none
  file=/media/nature/workspace1/InsMediaSDKGPU/deps/bmg/Source/arvoryol/code/Modules/Gfx/private/glfw/glfwDisplayMgr.cc
  line=48
  func=Oryol::_priv::OffscreenWindowPool::InitPool(size_t)::<lambda()>
  callstack:
/lib/libMediaSDK.so(_ZN5Oryol10StackTrace4DumpEPci+0x3d) [0x79ba6c4ab82d]
/lib/libMediaSDK.so(_ZN5Oryol3Log9AssertMsgEPKcS2_S2_iS2_+0x104) [0x79ba6c4a9b44]
/lib/libMediaSDK.so(+0x30601de) [0x79ba6c4cd1de]
/lib/x86_64-linux-gnu/libc.so.6(+0x99ee8) [0x79ba68ec2ee8]
/lib/libMediaSDK.so(_ZN5Oryol5_priv19OffscreenWindowPool8InitPoolEm+0x6d) [0x79ba6c4cc2bd]
/lib/x86_64-linux-gnu/libc.so.6(+0x99ee8) [0x79ba68ec2ee8]
/lib/libMediaSDK.so(_ZN5Oryol5_priv14glfwDisplayMgr4InitEm+0x6d) [0x79ba6c4cc6fd]
/lib/libMediaSDK.so(_ZN5Oryol19PlatformSetupStage1EPv+0x14) [0x79ba6c4cd6a4]
/lib/libMediaSDK.so(_ZN3ins7InitEnvEv+0x60) [0x79ba69fbc570]
MediaSDKTest(+0x86291) [0x5db58435f291]
/lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x79ba68e52d90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x79ba68e52e40]
MediaSDKTest(+0xa9ef5) [0x5db584382ef5]

Aborted (core dumped)

```